### PR TITLE
Add basic moderation

### DIFF
--- a/OpenAIModelAssistant.py
+++ b/OpenAIModelAssistant.py
@@ -11,8 +11,8 @@ logger.setLevel(logging.INFO)
 
 
 class OpenAIModelAssistant:
-    def __init__(self, api_key: str) -> None:
-        self.api_key = api_key
+    def __init__(self) -> None:
+        return
 
     def query_model(
         self,
@@ -56,6 +56,37 @@ class OpenAIModelAssistant:
     def get_moderation_score(
         self, message: str, openai_secret_key: str
     ) -> Tuple[str, float]:
+        """
+        Sample response from url:
+
+        {
+            "id": "modr-XXXXX",
+            "model": "text-moderation-001",
+            "results": [
+                {
+                "categories": {
+                    "hate": false,
+                    "hate/threatening": false,
+                    "self-harm": false,
+                    "sexual": false,
+                    "sexual/minors": false,
+                    "violence": false,
+                    "violence/graphic": false
+                },
+                "category_scores": {
+                    "hate": 0.18805529177188873,
+                    "hate/threatening": 0.0001250059431185946,
+                    "self-harm": 0.0003706029092427343,
+                    "sexual": 0.0008735615410842001,
+                    "sexual/minors": 0.0007470346172340214,
+                    "violence": 0.0041268812492489815,
+                    "violence/graphic": 0.00023186142789199948
+                },
+                "flagged": false
+                }
+            ]
+            }
+        """
         url = "https://api.openai.com/v1/moderations"
         headers = {"authorization": f"Bearer {openai_secret_key}"}
         payload = {"input": message}

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 Turbo is a quick and dirty chatbot that combines Discord.py and the OpenAI api. It queries the GPT 3.5 Turbo model.
 
 Add your discord and OpenAI API keys to a .env file, create a discord bot on the discord developer portal, and have fun!
+
+## Moderation
+
+All messages sent to Turbo are routed through the [OpenAI Moderation Endpoint](https://platform.openai.com/docs/guides/moderation). If any of the listed categories return as `true` then the message is not passed along to the gpt model and the user is warned.

--- a/tests/OpenAIModelAssistant_test.py
+++ b/tests/OpenAIModelAssistant_test.py
@@ -1,0 +1,115 @@
+import unittest
+from unittest.mock import Mock, patch
+from OpenAIModelAssistant import OpenAIModelAssistant
+
+
+class TestOpenAIModelAssistant(unittest.TestCase):
+    @patch("OpenAIModelAssistant.requests.post")
+    def test_get_moderation_score(self, mock_post):
+        message = "This is a test message"
+        openai_secret_key = "secret"
+        expected_result = ("hate", 0.99)
+        mock_response = {
+            "id": "modr-XXXXX",
+            "model": "text-moderation-001",
+            "results": [
+                {
+                    "categories": {
+                        "hate": True,
+                        "hate/threatening": False,
+                        "self-harm": False,
+                        "sexual": False,
+                        "sexual/minors": False,
+                        "violence": False,
+                        "violence/graphic": False,
+                    },
+                    "category_scores": {
+                        "hate": 0.99,
+                        "hate/threatening": 0.0001250059431185946,
+                        "self-harm": 0.0003706029092427343,
+                        "sexual": 0.0008735615410842001,
+                        "sexual/minors": 0.0007470346172340214,
+                        "violence": 0.0041268812492489815,
+                        "violence/graphic": 0.00023186142789199948,
+                    },
+                    "flagged": False,
+                }
+            ],
+        }
+        mock_post.return_value.json.return_value = mock_response
+        assistant = OpenAIModelAssistant()
+
+        result = assistant.get_moderation_score(message, openai_secret_key)
+
+        self.assertEqual(result, expected_result)
+        mock_post.assert_called_once_with(
+            url="https://api.openai.com/v1/moderations",
+            json={"input": message},
+            headers={"authorization": f"Bearer {openai_secret_key}"},
+        )
+
+    def test_category_score(self):
+        moderation_response = {
+            "results": [
+                {
+                    "categories": {
+                        "hate": True,
+                        "hate/threatening": False,
+                        "self-harm": False,
+                        "sexual": False,
+                        "sexual/minors": False,
+                        "violence": False,
+                        "violence/graphic": False,
+                    },
+                    "category_scores": {
+                        "hate": 0.99,
+                        "hate/threatening": 0.0001250059431185946,
+                        "self-harm": 0.0003706029092427343,
+                        "sexual": 0.0008735615410842001,
+                        "sexual/minors": 0.0007470346172340214,
+                        "violence": 0.0041268812492489815,
+                        "violence/graphic": 0.00023186142789199948,
+                    },
+                    "flagged": False,
+                }
+            ]
+        }
+        expected_result = ("hate", 0.99)
+        assistant = OpenAIModelAssistant()
+
+        result = assistant._category_score(moderation_response)
+
+        self.assertEqual(result, expected_result)
+
+    def test_category_score_no_harmful_category(self):
+        moderation_response = {
+            "results": [
+                {
+                    "categories": {
+                        "hate": False,
+                        "hate/threatening": False,
+                        "self-harm": False,
+                        "sexual": False,
+                        "sexual/minors": False,
+                        "violence": False,
+                        "violence/graphic": False,
+                    },
+                    "category_scores": {
+                        "hate": 0.0,
+                        "hate/threatening": 0.0,
+                        "self-harm": 0.0,
+                        "sexual": 0.0,
+                        "sexual/minors": 0.0,
+                        "violence": 0.0,
+                        "violence/graphic": 0.0,
+                    },
+                    "flagged": False,
+                }
+            ]
+        }
+        expected_result = (None, 0.0)
+        assistant = OpenAIModelAssistant()
+
+        result = assistant._category_score(moderation_response)
+
+        self.assertEqual(result, expected_result)

--- a/turbo.py
+++ b/turbo.py
@@ -38,7 +38,7 @@ secret_prompt = (
 )
 
 chat_context = ChatContext(secret_prompt=secret_prompt)
-assistant = OpenAIModelAssistant(api_key=OPENAI_SECRET_TOKEN)
+assistant = OpenAIModelAssistant()
 
 intents = discord.Intents.default()
 intents.message_content = True

--- a/turbo.py
+++ b/turbo.py
@@ -81,6 +81,18 @@ async def turbo(ctx, *, arg):
             "_(turbo's host here: sorry! you need the `turbo` roll to talk to turbo)_"
         )
 
+    # moderation
+    max_category, max_score = assistant.get_moderation_score(
+        message=arg, openai_secret_key=OPENAI_SECRET_TOKEN
+    )
+    if max_category:
+        print(
+            f"_(turbos host here: you've breached the content moderation threshold breached - category: {max_category} - score: {max_score}.  Keep it safe and friendly please!)_"
+        )
+        await ctx.send(f"moderation threshold breached - {max_category} - {max_score}")
+        return
+    print(f"moderation score - {max_category} - {max_score}")
+
     # add user message to the context
     chat_context.add_message(content=arg, role="user")
 

--- a/turbo.py
+++ b/turbo.py
@@ -80,6 +80,7 @@ async def turbo(ctx, *, arg):
         await ctx.send(
             "_(turbo's host here: sorry! you need the `turbo` roll to talk to turbo)_"
         )
+        return
 
     # moderation
     max_category, max_score = assistant.get_moderation_score(


### PR DESCRIPTION
Adding basic moderation . 

- Query the [OpenAI moderation endpoint](https://platform.openai.com/docs/guides/moderation)
- correctly return when users do not have the turbo role
- add some basic tests for moderation functions 